### PR TITLE
Fix pom.xml to use vaadin.version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <gwtVersion>2.7.0</gwtVersion>
+    <vaadin.version>7.4.8</vaadin.version>
 
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
@@ -53,7 +54,7 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-widgets</artifactId>
-      <version>7.4.0</version>
+      <version>${vaadin.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
I'd like to be able to use -Dvaadin.version to override the current version used.